### PR TITLE
netopeer2: config: listen on ipv6 as well

### DIFF
--- a/netopeer2/files/netopeer2-server-merge-config.default
+++ b/netopeer2/files/netopeer2-server-merge-config.default
@@ -17,7 +17,7 @@ CONFIG="<netconf-server xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-server\
             <name>default-ssh</name>
             <ssh>
                 <tcp-server-parameters>
-                    <local-address>0.0.0.0</local-address>
+                    <local-address>::</local-address>
                     <keepalives>
                         <idle-time>1</idle-time>
                         <max-probes>10</max-probes>


### PR DESCRIPTION
The default 0.0.0.0 local address makes Netopeer2 listen only on IPv4.
This has been changed to :: in order to listen on both IPv4 and IPv6.

Signed-off-by: Jakov Petrina <jakov.petrina@sartura.hr>